### PR TITLE
Updated the error code when exiting without any issues found.

### DIFF
--- a/joft/base.py
+++ b/joft/base.py
@@ -65,7 +65,7 @@ def execute_template(template_file_path: str, jira_session: jira.JIRA) -> int:
                     f"'{jira_template.jira_search.jql}'!"
                 )
             )
-            return 1
+            return 0
 
         # when the jira query is successfull the actions of template will be then executed
         # for each ticket in the query

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -326,7 +326,7 @@ def test_execute_template_exit_no_tickets(
 
         ret_code = joft.base.execute_template(yaml_file_path, mock_jira_session)
 
-    assert ret_code == 1
+    assert ret_code == 0
 
     assert mock_execute_actions_per_trigger_ticket.call_count == 0
     assert mock_execute_actions.call_count == 0


### PR DESCRIPTION
Changed it from 1 to 0 as in the end this is not an error. Also when running several templates the first which will not find any issues, will stop the whole CI pipeline/container. Which is not desirable.